### PR TITLE
Fix/#97 oauth 구글 유저 로그인상태 갱신

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -11,7 +11,15 @@ const apiClient = axios.create({
     },
 });
 
-const excludedUrls = ['/api/login', '/api/signup'];
+const excludedUrls = [
+    '/api/login',
+    '/api/signup',
+    "/api/users/check-duplicate",
+    "/api/mongo/camps/search",
+    "/api/camps/*/available",
+    "/api/camps/*",
+    "/api/keywords"];
+
 let isRefreshing = false; // Refresh Token 갱신 중 여부
 let refreshSubscribers = []; // 갱신 후 재요청 대기열
 
@@ -52,7 +60,7 @@ apiClient.interceptors.response.use(
         return response;
     },
     async (error) => {
-        console.error("⚠️ 응답 에러:", error.message);
+        console.error("🚫️ 응답 에러:", error.message);
         const originalRequest = error.config;
 
         // 특정 URL에 대해 인터셉터 제외

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,5 +1,5 @@
-import React, {createContext, useEffect, useState} from 'react';
-import {userService} from "../api/services/userService";
+import React, { createContext, useEffect, useState, useCallback } from 'react';
+import { userService } from "api/services/userService";
 
 const AuthContext = createContext();
 
@@ -17,28 +17,28 @@ export const AuthProvider = ({ children }) => {
         });
     }, []);
 
-    const login = () => {
-        setAuth({
-            ...auth,
+    const login = useCallback(() => {
+        setAuth((prevAuth) => ({
+            ...prevAuth,
             isAuthenticated: true
-        });
-    };
+        }));
+    }, []);
 
     const logout = async () => {
         try {
             await userService.logout();
             localStorage.removeItem('accessToken');
-            setAuth({
-                ...auth,
+            setAuth((prevAuth) => ({
+                ...prevAuth,
                 isAuthenticated: false
-            });
+            }));
         } catch (error) {
             console.error('Logout failed:', error);
         }
     };
 
     return (
-        <AuthContext.Provider value={{...auth, login, logout}}>
+        <AuthContext.Provider value={{ ...auth, login, logout }}>
             {children}
         </AuthContext.Provider>
     );
@@ -48,4 +48,4 @@ export const useAuth = () => {
     return React.useContext(AuthContext);
 };
 
-export default AuthContext; 
+export default AuthContext;

--- a/src/pages/account/OAuthSuccess.js
+++ b/src/pages/account/OAuthSuccess.js
@@ -3,9 +3,11 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import CircularProgress from "@mui/material/CircularProgress"; // Material-UI 스피너 import
 import Box from "@mui/material/Box";
+import {useAuth} from "context/AuthContext";
 
 const OAuthSuccess = () => {
     const navigate = useNavigate();
+    const { login } = useAuth();
 
     useEffect(() => {
         const fetchTokens = async () => {
@@ -17,6 +19,7 @@ const OAuthSuccess = () => {
 
                 // 토큰 저장 (예: Local Storage)
                 localStorage.setItem("accessToken", response.data.accessToken);
+                login();
 
                 // 페이지 이동
                 navigate("/");

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,20 +6,19 @@ import Login from "./account/Login";
 import ProfileView from "./account/ProfileView";
 import Signup from './account/SignUp';
 import UpdateProfile from "./account/UpdateProfile";
-
-//error
-import NotFound from "./error/NotFound";
+import OAuthSuccess from "pages/account/OAuthSuccess";
 
 //home
 import Home from "./home/Home";
 import Keyword from "./home/Keyword";
 
-//reservation
+//etc
+import CampDetail from "pages/camp/CampDetail";
 import MyReservation from "./reservation/MyReservation";
 import Reservation from "./reservation/Reservation";
-
-//search
 import Search from "./search/Search";
+import NotFound from "./error/NotFound";
+
 
 export {
     DeleteAccount,
@@ -35,4 +34,6 @@ export {
     MyReservation,
     Reservation,
     Search,
+    CampDetail,
+    OAuthSuccess
 };

--- a/src/router/Router.js
+++ b/src/router/Router.js
@@ -1,10 +1,8 @@
 import {Navigate, Route, Routes} from "react-router-dom";
-import { Login, MyPage, Signup } from 'pages';
+import { Login, MyPage, Signup, OAuthSuccess } from 'pages';
 import { NotFound, Home, Keyword} from 'pages';
 import { MyReservation, Reservation } from 'pages';
-import { Search } from 'pages';
-import CampDetail from "pages/camp/CampDetail";
-import OAuthSuccess from "../pages/account/OAuthSuccess";
+import { Search, CampDetail } from 'pages';
 // import CampList from "pages/camp/CampList";
 // import CreateReview from "pages/review/CreateReview";
 // import CampSiteList from 'pages/camp/CampSiteList';
@@ -26,7 +24,7 @@ function Router() {
             <Route path="/not-found" element={<NotFound/>}/>
             <Route path="/search" element={<Search/>} />
             <Route path="/camps/:campId/sites/:siteId" element={<Reservation/>}/>
-            <Route path="/oauth/success" element={<OAuthSuccess/> }/>
+            <Route path="/oauth/success" element={<OAuthSuccess />} />
         </Routes>
     );
 }


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

구글 유저 로그인상태 갱신

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 구글 유저 로그인상태 갱신하는 코드 추가
- [x] `axiosConfig`의 excludeUrl 추가
- [x]  login은 자주쓰여서 useCallback 으로 이모제이션

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- oauthSuccess 페이지에서 로그인상태 갱신하고 리다이렉트 하도록 코드 수정
- `axiosConfig`의 excludeUrl 추가

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

구글 유저는 배포서버에서 도메인 연결문제가 있는데 이것은 다시 확인해봐야함

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #97
