### PR TITLE
Feat/#115 캘린더와 연동되는 예약 가능한 캠핑지 리스트 추가

### DIFF
--- a/src/components/OperationPolicy.js
+++ b/src/components/OperationPolicy.js
@@ -13,8 +13,8 @@ const OperationPolicy = ({
     if (showDefaultPolicies) {
         const defaultPolicies = [
             { label: '매너타임', value: '시작 22:00 | 종료 07:00' },
-            { label: '오토캠핑', value: '입실 14:00 | 퇴실 11:00' },
-            { label: '글램핑', value: '입실 14:00 | 퇴실 11:00' },
+            { label: '오토캠핑', value: '입실 15:00 | 퇴실 11:00' },
+            { label: '글램핑', value: '입실 15:00 | 퇴실 11:00' },
         ];
         policyData.push(...defaultPolicies);
     }

--- a/src/components/camp/AddressInfo.js
+++ b/src/components/camp/AddressInfo.js
@@ -1,0 +1,37 @@
+import React from "react";
+import WebIcon from "@mui/icons-material/Web";
+import CallIcon from "@mui/icons-material/Call";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+
+const AddressInfo = ({ address, tel, homepage }) => (
+    <div className="camp-detail-info-bar">
+        {/* 도로명 주소 */}
+        <div className="info-bar-section">
+            <LocationOnIcon style={{ verticalAlign: "middle", marginRight: "8px" }} />
+            <span>{address || "도로명 주소 정보 없음"}</span>
+        </div>
+        {/* 연락처 */}
+        <div className="info-bar-section">
+            <CallIcon style={{ verticalAlign: "middle", marginRight: "8px" }} />
+            <span>{tel || "연락처 정보 없음"}</span>
+        </div>
+        {/* 홈페이지 */}
+        <div className="info-bar-section">
+            <WebIcon style={{ verticalAlign: "middle", marginRight: "8px" }} />
+            {homepage ? (
+                <a
+                    href={homepage}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="homepage-link"
+                >
+                    {homepage}
+                </a>
+            ) : (
+                "홈페이지 정보 없음"
+            )}
+        </div>
+    </div>
+);
+
+export default AddressInfo;

--- a/src/components/camp/AvailableCampSiteList.js
+++ b/src/components/camp/AvailableCampSiteList.js
@@ -1,0 +1,19 @@
+import React from "react";
+import CampSiteCard from "./CampSiteCard";
+
+const AvailableCampSiteList = ({ campSites }) => {
+    return (
+        <div>
+            {campSites.map((site) => (
+                <CampSiteCard
+                    key={site.siteId}
+                    data={site}
+                    count={1}
+                    onReserve={() => alert(`예약: ${site.siteType}`)}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default AvailableCampSiteList;

--- a/src/components/camp/AvailableCampSites.js
+++ b/src/components/camp/AvailableCampSites.js
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import useAvailableCampSites from "../../hooks/useAvailableCampSites";
+
+const AvailableCampSites = ({ campId }) => {
+    const [checkin, setCheckin] = useState("");
+    const [checkout, setCheckout] = useState("");
+
+    const { loading, error, data: campSites } = useAvailableCampSites(campId, checkin, checkout);
+
+    const handleSearch = () => {
+        if (!checkin || !checkout) {
+            alert("체크인과 체크아웃 날짜를 입력하세요.");
+            return;
+        }
+        // 이미 데이터 로드가 자동으로 시작됨
+    };
+
+    return (
+        <div>
+            <h1>예약 가능한 캠핑지 목록</h1>
+            <div>
+                <label>
+                    체크인 날짜:
+                    <input
+                        type="date"
+                        value={checkin}
+                        onChange={(e) => setCheckin(e.target.value)}
+                    />
+                </label>
+                <label>
+                    체크아웃 날짜:
+                    <input
+                        type="date"
+                        value={checkout}
+                        onChange={(e) => setCheckout(e.target.value)}
+                    />
+                </label>
+                <button onClick={handleSearch}>검색</button>
+            </div>
+
+            {loading && <p>로딩 중...</p>}
+            {error && <p>에러 발생: {error}</p>}
+            {campSites.length > 0 ? (
+                <ul>
+                    {campSites.map((site) => (
+                        <li key={site.id}>{site.name}</li>
+                    ))}
+                </ul>
+            ) : (
+                !loading && <p>예약 가능한 캠핑지가 없습니다.</p>
+            )}
+        </div>
+    );
+};
+
+export default AvailableCampSites;

--- a/src/components/camp/CampDatePicker.js
+++ b/src/components/camp/CampDatePicker.js
@@ -1,0 +1,19 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+import { ko } from "date-fns/locale";
+import "react-datepicker/dist/react-datepicker.css";
+import "../../style/camp-date-picker.css";
+
+const CampDatePicker = ({ checkin, checkout, handleDateChange }) => (
+    <DatePicker
+        locale={ko} // 한글 로케일 적용
+        selected={checkin}
+        onChange={handleDateChange}
+        startDate={checkin}
+        endDate={checkout}
+        selectsRange
+        inline
+    />
+);
+
+export default CampDatePicker;

--- a/src/components/camp/CampDetailIntro.js
+++ b/src/components/camp/CampDetailIntro.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+const CampDetailIntro = ({ intro }) => (
+    <div className="camp-detail-intro-box">
+        <span className="camp-detail-intro-title">캠핑장 소개</span>
+        <p className="camp-detail-description">
+            {intro || "장문 소개 정보 없음"}
+        </p>
+    </div>
+);
+
+export default CampDetailIntro;

--- a/src/components/camp/CampSiteCard.js
+++ b/src/components/camp/CampSiteCard.js
@@ -1,17 +1,14 @@
 import React from "react";
-import {Card, CardContent, Typography, Box } from "@mui/material";
-import YellowButton from "./YellowButton";
-import {TableBarOutlined} from "@mui/icons-material";
-import ReceiptLongOutlinedIcon from '@mui/icons-material/ReceiptLongOutlined';
-import UpdateOutlinedIcon from '@mui/icons-material/UpdateOutlined';
-import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined';
-
-
-
+import { Card, CardContent, Typography, Box } from "@mui/material";
+import YellowButton from "../YellowButton";
+import { TableBarOutlined } from "@mui/icons-material";
+import ReceiptLongOutlinedIcon from "@mui/icons-material/ReceiptLongOutlined";
+import UpdateOutlinedIcon from "@mui/icons-material/UpdateOutlined";
+import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 
 const getImageBySiteType = (siteType) => {
     const imageMap = {
-        "카라반" : "/default/카라반.png",
+        "카라반": "/default/카라반.png",
         "일반": "/default/일반.png",
         "오토": "/default/오토.png",
         "글램핑": "/default/글램핑.png",
@@ -20,10 +17,20 @@ const getImageBySiteType = (siteType) => {
     return imageMap[siteType] || "profile.png"; // 기본 이미지
 };
 
-const CampSiteCard = ({ data, count, onReserve }) => {
-    const { siteType, maximumPeople, price, checkInTime, checkOutTime, indoorFacility } = data;
+// const CampSiteCard = ({ data, count, onReserve }) => {
+//     const { siteType, maximumPeople, price, checkInTime, checkOutTime, indoorFacility } = data;
+
+const CampSiteCard = ({ data = {}, count = 1, onReserve = () => {} }) => {
+    // 기본값 설정
+    const {
+        siteType = "알 수 없음",
+        maximumPeople = 0,
+        price = 0,
+        indoorFacility = "정보 없음",
+    } = data;
 
     const image = getImageBySiteType(siteType);
+
     return (
         <Card
             sx={{
@@ -51,7 +58,9 @@ const CampSiteCard = ({ data, count, onReserve }) => {
             {/* 정보 섹션 */}
             <Box sx={{ display: "flex", flexDirection: "column", flex: "3", padding: 2 }}>
                 <CardContent>
-                    <Typography variant="h5" sx={{marginBottom: 2, fontWeight: 'bold'}}>{siteType}</Typography>
+                    <Typography variant="h5" sx={{ marginBottom: 2, fontWeight: "bold" }}>
+                        {siteType}
+                    </Typography>
                     <Box sx={{ display: "flex", alignItems: "center", marginBottom: 1 }} />
                     <Box sx={{ display: "flex", alignItems: "center", marginBottom: 1 }}>
                         <TableBarOutlined sx={{ fontSize: 20, marginRight: 1, color: "primary.main" }} />
@@ -69,14 +78,18 @@ const CampSiteCard = ({ data, count, onReserve }) => {
                     </Box>
                     <Box sx={{ display: "flex", alignItems: "center", marginBottom: 1 }}>
                         <ReceiptLongOutlinedIcon sx={{ fontSize: 20, marginRight: 1, color: "green" }} />
-                        <Typography variant="body2">1박당 {price.toLocaleString()}원</Typography>
+                        <Typography variant="body2">
+                            1박당 {price.toLocaleString()}원
+                        </Typography>
                     </Box>
                 </CardContent>
 
                 {/* 액션 버튼 */}
                 <Box sx={{ marginTop: "auto", textAlign: "right" }}>
                     {/* 총액 */}
-                    <Typography variant={"h6"}>총 결제 금액: {(price * count).toLocaleString()}원</Typography>
+                    <Typography variant={"h6"}>
+                        총 결제 금액: {(price * count).toLocaleString()}원
+                    </Typography>
                     {/* 예약 버튼 */}
                     <YellowButton onClick={onReserve}>예약하기</YellowButton>
                 </Box>
@@ -86,4 +99,3 @@ const CampSiteCard = ({ data, count, onReserve }) => {
 };
 
 export default CampSiteCard;
-

--- a/src/components/camp/ImageGallery.js
+++ b/src/components/camp/ImageGallery.js
@@ -1,0 +1,42 @@
+import React from "react";
+
+const ImageGallery = ({ images, onMoreClick }) => {
+    // 이미지 클릭 핸들러
+    const handleImageClick = (imageSrc) => {
+        window.open(imageSrc, "_blank"); // 새 탭에서 이미지 열기
+    };
+
+    return (
+        <div className="camp-detail-gallery">
+            {/* 대표 이미지 */}
+            {images && images.length > 1 && (
+                <div className="main-image" onClick={() => handleImageClick(images[1])}>
+                    <img src={images[1]} alt="대표 이미지" /> {/* 두 번째 사진 */}
+                </div>
+            )}
+            {/* 썸네일 이미지 */}
+            <div className="thumbnail-images-grid">
+                {images &&
+                    [0, 2, 3, 4].map(
+                        (index) =>
+                            images[index] && (
+                                <div
+                                    key={index}
+                                    className="thumbnail"
+                                    onClick={() => handleImageClick(images[index])}
+                                >
+                                    <img src={images[index]} alt={`이미지 ${index + 1}`} />
+                                </div>
+                            )
+                    )}
+                {images.length > 5 && (
+                    <button onClick={onMoreClick} className="view-more-button">
+                        더보기
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ImageGallery;

--- a/src/components/camp/MapSection.js
+++ b/src/components/camp/MapSection.js
@@ -1,0 +1,22 @@
+import React from "react";
+import KakaoMap from "../../components/KakaoMap";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+
+const MapSection = ({ latitude, longitude, name, state }) => (
+    <div className="map-wrapper">
+        <h2 className="location-info-title">
+            <LocationOnIcon style={{ verticalAlign: "middle", marginRight: "8px" }} />
+            위치 정보
+        </h2>
+        <div className="map-container">
+            <KakaoMap
+                latitude={latitude}
+                longitude={longitude}
+                locationName={name}
+                state={state}
+            />
+        </div>
+    </div>
+);
+
+export default MapSection;

--- a/src/components/camp/ModalComponent.js
+++ b/src/components/camp/ModalComponent.js
@@ -1,0 +1,18 @@
+import React from "react";
+import "../../style/modal-component.css";
+
+const ModalComponent = ({ open, onClose, title, message }) => {
+    if (!open) return null; // 모달이 닫힌 상태이면 렌더링하지 않음
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <h3>{title}</h3>
+                <p>{message}</p>
+                <button onClick={onClose}>닫기</button>
+            </div>
+        </div>
+    );
+};
+
+export default ModalComponent;

--- a/src/components/camp/ModalGallery.js
+++ b/src/components/camp/ModalGallery.js
@@ -1,0 +1,33 @@
+import React from "react";
+import Modal from "@mui/material/Modal";
+import Box from "@mui/material/Box";
+
+const ModalGallery = ({ open, onClose, images }) => (
+    <Modal open={open} onClose={onClose}>
+        <Box
+            sx={{
+                p: 4,
+                backgroundColor: "white",
+                maxHeight: "83vh",
+                overflow: "auto",
+                width: "87%",
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                boxShadow: 24,
+                borderRadius: 2,
+            }}
+        >
+            <div className="modal-content">
+                {images.map((image, index) => (
+                    <div key={index} className="modal-thumbnail">
+                        <img src={image} alt={`이미지 ${index + 1}`} className="modal-image" />
+                    </div>
+                ))}
+            </div>
+        </Box>
+    </Modal>
+);
+
+export default ModalGallery;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,7 +6,7 @@ import ProfileCard from "./ProfileCard";
 import ScrollToTopFab from "./ScrollToTopFab";
 import WhiteButton from "./WhiteButton";
 import YellowButton from "./YellowButton";
-import CampSiteCard from "./CampSiteCard";
+import CampSiteCard from "./camp/CampSiteCard";
 import CampReservationCard from "./CampReservationCard";
 import ReservationConfirmCard from "./ReservationConfirmCard";
 import MainCarousel from "./MainCarousel";

--- a/src/hooks/useAvailableCampSites.js
+++ b/src/hooks/useAvailableCampSites.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+import { campSiteService } from "../api/services/campSiteService";
+
+const useAvailableCampSites = (campId, checkin, checkout) => {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [data, setData] = useState([]);
+
+    useEffect(() => {
+        if (!checkin || !checkout) return;
+
+        const fetchAvailableCampSites = async () => {
+            setLoading(true);
+            try {
+                const response = await campSiteService.getAvailableCampSites(
+                    campId,
+                    checkin,
+                    checkout
+                );
+                setData(response.data);
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchAvailableCampSites();
+    }, [campId, checkin, checkout]);
+
+    return { loading, error, data };
+};
+
+export default useAvailableCampSites;

--- a/src/hooks/useCampDetail.js
+++ b/src/hooks/useCampDetail.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { campService } from "../api/services/campService";
+
+export const useCampDetail = (campId) => {
+    const [campDetails, setCampDetails] = useState({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchCampDetails = async () => {
+            try {
+                const response = await campService.getCampDetail(campId);
+                setCampDetails(response.data);
+            } catch (err) {
+                console.error(err);
+                setError(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchCampDetails();
+    }, [campId]);
+
+    return { campDetails, loading, error };
+};

--- a/src/style/available-list.css
+++ b/src/style/available-list.css
@@ -1,0 +1,58 @@
+/* 캠핑지 리스트 전체 컨테이너 */
+.camp-site-list-available {
+    margin-top: 0px;
+}
+
+/* 개별 캠핑지 카드 */
+.camp-site-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 20px;
+    margin-bottom: 15px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+/* 카드 hover 효과 */
+.camp-site-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* 카드 제목 스타일 */
+.camp-site-card h3 {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+    color: #333;
+}
+
+/* 카드의 각 정보 행 스타일 */
+.camp-site-card p {
+    margin: 5px 0;
+    font-size: 1rem;
+    color: #555;
+}
+
+/* 예약 버튼 스타일 */
+.camp-site-card button {
+    background-color: #ffc400; /* YellowButton과 동일한 색상 */
+    color: #fff;
+    border: none;
+    border-radius: 0.375rem; /* YellowButton과 동일한 둥근 모서리 */
+    padding: 8px 16px; /* YellowButton의 small 크기와 동일한 패딩 */
+    font-size: 1rem; /* YellowButton의 small 크기와 동일한 폰트 크기 */
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    align-self: flex-end; /* 버튼을 카드 오른쪽 하단에 위치시킴 */
+}
+
+/* 버튼 hover 효과 */
+.camp-site-card button:hover {
+    background-color: #FCD34D; /* YellowButton hover 효과 색상 */
+}

--- a/src/style/camp-date-picker.css
+++ b/src/style/camp-date-picker.css
@@ -1,0 +1,84 @@
+.react-datepicker {
+    transform: scale(1.5); /* 크기 확대 */
+    transform-origin: top center; /* 확대 기준점을 중앙으로 설정 */
+    margin-bottom: 0; /* 달력과 아래 텍스트의 간격 제거 */
+    width: auto; /* 자동 크기 */
+    text-align: center; /* 달력 텍스트 가운데 정렬 */
+}
+
+/* 텍스트 크기 조정 */
+.react-datepicker__day,
+.react-datepicker__day-name,
+.react-datepicker__current-month {
+    font-size: 1.2rem; /* 텍스트 크기 확대 */
+    text-align: center; /* 텍스트를 가운데 정렬 */
+}
+
+/* 날짜 선택 영역 패딩 및 크기 조정 */
+.react-datepicker__month {
+    padding: 20px; /* 패딩 설정 */
+    max-width: 600px; /* 최대 가로 길이 설정 */
+    display: flex; /* 플렉스 박스 활성화 */
+    flex-direction: column; /* 세로 정렬 */
+    align-items: center; /* 항목을 가운데 정렬 */
+}
+
+/* 컨테이너 스타일 */
+.camp-date-picker-container {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column; /* 세로 정렬 */
+    align-items: center; /* 내부 요소 가운데 정렬 */
+    gap: 10px; /* 간격 추가 */
+}
+
+/* 달력 아래 텍스트 박스 스타일 */
+.date-info {
+    display: flex;
+    justify-content: center; /* 중앙 정렬 */
+    gap: 20px; /* 입실/퇴실 간격 */
+    margin-top: 132px; /* 달력과 텍스트 박스 간격 축소 */
+    padding: 10px; /* 내부 여백 */
+    background-color: #ffd672; /* 배경 색상 */
+    border: 1.5px solid #c3c3c3;
+    border-radius: 8px; /* 모서리 둥글게 */
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 그림자 효과 */
+    width: 424px; /* 고정된 가로 크기 */
+    height: auto; /* 높이는 내용에 따라 자동으로 조정 */
+}
+
+/* 개별 텍스트 박스 스타일 */
+.date-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+/* 라벨 텍스트 스타일 */
+.label {
+    font-size: 14px;
+    color: #555;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+/* 날짜 텍스트 스타일 */
+.date {
+    font-size: 16px;
+    color: #222;
+    font-weight: bold;
+}
+
+
+.label {
+    font-size: 14px;
+    color: #555;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.date {
+    font-size: 16px;
+    color: #222;
+    font-weight: bold;
+}

--- a/src/style/camp-detail.css
+++ b/src/style/camp-detail.css
@@ -125,7 +125,7 @@
 .camp-detail-gallery {
     display: grid;
     grid-template-columns: 1fr 1fr; /* 왼쪽과 오른쪽을 동일한 비율로 나눔 */
-    gap: 7px; /* 이미지 간의 간격 */
+    gap: 5px; /* 이미지 간의 간격 */
     margin: 20px 0;
     height: 600px; /* 전체 높이를 고정하여 1:1 비율 유지 */
 }
@@ -147,7 +147,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr; /* 2x2 형태로 썸네일 배치 */
     grid-template-rows: 1fr 1fr;
-    gap: 7px; /* 썸네일 간의 간격 */
+    gap: 5px; /* 썸네일 간의 간격 */
     height: 600px; /* 부모 높이에 맞추기 */
     position: relative; /* 내부 요소 위치 설정을 위해 상대 위치 사용 */
 }

--- a/src/style/modal-component.css
+++ b/src/style/modal-component.css
@@ -1,0 +1,34 @@
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+button {
+    margin-top: 10px;
+    padding: 10px 20px;
+    background-color: #fcd34d;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #0056b3;
+}


### PR DESCRIPTION
## 📌 목적
- 캠핑장 상세 페이지에서 예약 가능한 캠핑지 리스트를 구현하고 이를 캘린더와 연동하여 사용자가 쉽게 예약할 수 있도록 기능을 추가합니다

## 🛠️ 작업 상세 내용
- [x] API에서 예약 가능한 캠핑지 데이터를 불러오는 로직 추가 (useAvailableCampSites 활용)
- [x] 캠핑지 정보를 기반으로 리스트를 렌더링하는 CampSiteCard 컴포넌트 추가 및 데이터 바인딩
- [x]  사용자가 선택한 날짜에 따라 데이터 필터링 기능 구현
- [x]  당일 예약 시 모달로 안내하는 기능 추가
- [x]  디자인 및 스타일 업데이트 (사용자 친화적이고 직관적인 UI 구성)
