### PR TITLE
Fix/#121 캘린더 기능 수정

### DIFF
--- a/src/components/camp/CampDatePicker.js
+++ b/src/components/camp/CampDatePicker.js
@@ -4,16 +4,30 @@ import { ko } from "date-fns/locale";
 import "react-datepicker/dist/react-datepicker.css";
 import "../../style/camp-date-picker.css";
 
-const CampDatePicker = ({ checkin, checkout, handleDateChange }) => (
-    <DatePicker
-        locale={ko} // 한글 로케일 적용
-        selected={checkin}
-        onChange={handleDateChange}
-        startDate={checkin}
-        endDate={checkout}
-        selectsRange
-        inline
-    />
-);
+const CampDatePicker = ({ checkin, checkout, handleDateChange }) => {
+    const today = new Date(); // 오늘 날짜 기준
+
+    return (
+        <DatePicker
+            locale={ko} // 한글 로케일 적용
+            selected={checkin}
+            onChange={(dates) => {
+                const [start, end] = dates || [null, null];
+                if (start && end) {
+                    const dayDifference = (end - start) / (1000 * 60 * 60 * 24); // 날짜 차이 계산
+                    if (dayDifference < 1) {
+                        return dayDifference >= 1;
+                    }
+                }
+                handleDateChange(dates); // 유효한 날짜만 반영
+            }}
+            startDate={checkin}
+            endDate={checkout}
+            selectsRange
+            inline
+            minDate={today} // 오늘 이후 날짜만 선택 가능
+        />
+    );
+};
 
 export default CampDatePicker;


### PR DESCRIPTION
## 📌 목적
- 캘린더에서 이전 날짜를 선택 못하게 막고 1박 이상만 선택하도록 프론트를 수정하기 위해서

## 🛠️ 작업 상세 내용
- [x] 캘린더에서 이전 날짜 선택 못하게 비활성화 하기
- [x] 1박 이상만 선택하도록 입실일과 퇴실일을 같은날로 선택 못하게 하기

## ⚠️ 주의 사항
- 예약에 성공하면 달력에서 해당 날짜를 비활성화 하고, 예약이 취소 되면 다시 활성화 시키는건 추후 연결할 예정
