### PR TITLE
Fix/#133 검색 페이지에서 검색 시 파라미터 값을 전해주지 못하는 문제

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -25,6 +25,7 @@ import ModalComponent from "./camp/ModalComponent";
 import MapSection from "./camp/MapSection";
 import ModalGallery from "./camp/ModalGallery";
 import KeywordSelection from "./main/KeywordSelection";
+import NoResultsFound from "./main/NoResultsFound";
 
 export {
     Calendar,
@@ -54,4 +55,5 @@ export {
     MapSection,
     ModalGallery,
     KeywordSelection,
+    NoResultsFound,
 };

--- a/src/components/main/NoResultsFound.js
+++ b/src/components/main/NoResultsFound.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Box, Typography, SvgIcon } from '@mui/material';
+
+// Tent Icon (커스텀 SVG 아이콘)
+const TentIcon = (props) => (
+    <SvgIcon {...props}>
+        <path d="M12 2L1 21h22L12 2zm0 3.27L19.74 19H4.26L12 5.27zM11 13h2v2h-2v-2zm0-4h2v3h-2V9z" />
+    </SvgIcon>
+);
+
+const NoResultsFound = () => {
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center', // 정중앙 배치
+                height: '50vh', // 화면 전체 높이를 기준으로 중앙 정렬
+                color: 'text.secondary',
+            }}
+        >
+            <TentIcon sx={{ fontSize: 64, mb: 2, color: '#999' }} />
+            <Typography variant="body2" color="text.secondary">
+                검색 내용에 대한 캠핑장 검색 결과가 없습니다.
+            </Typography>
+        </Box>
+    );
+};
+
+export default NoResultsFound;


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.
검색 페이지에서 검색 시 파라미터 값을 읽지 못하고 빈 검색페이지 반환 수

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [ ] 빈 검색 결과창에 대한 UI 변경
- [ ] 로딩 UI 적용
- [ ] 검색페이지의 검색어에 대한 검색결과 겹침 문제 + 초기화 문제 해결

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 예: `UserService` 클래스에 새로운 메서드 추가

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #133 
