### PR TITLE
fix: #151 나의예약목록에 디폴트 이미지 못 불러오는 버그 해결

### DIFF
--- a/src/components/reservation/CampReservationCard.js
+++ b/src/components/reservation/CampReservationCard.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { defaultThumbnails, getRandomThumbnail } from "../../utils/ThumbnailUtils"; // 함수와 배열 임포트
+import { getRandomThumbnail } from "../../utils/ThumbnailUtils";
 import {
     Card,
     CardContent,
@@ -165,8 +165,6 @@ const CampReservationCard = ({ data, onReviewChange }) => {
 
     const buttonProps = getButtonProps();
 
-    const imageUrl = campResponseDto.thumbImage === "" ? getRandomThumbnail(defaultThumbnails) : campResponseDto.thumbImage;
-
     return (
         <Card
             sx={{
@@ -182,15 +180,33 @@ const CampReservationCard = ({ data, onReviewChange }) => {
             <Box
                 sx={{
                     flex: { sm: "2" },
-                    backgroundImage: `url(${imageUrl})`,
-                    backgroundSize: "cover",
-                    backgroundPosition: "center",
                     height: { xs: 200, sm: "auto" },
                     aspectRatio: { sm: "16 / 9" },
                     width: { xs: "100%", sm: "auto" },
+                    ...(campResponseDto.thumbImage ? {
+                        backgroundImage: `url(${campResponseDto.thumbImage})`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                    } : {
+                        position: 'relative'
+                    })
                 }}
-            />
-
+            >
+                {(!campResponseDto.thumbImage || campResponseDto.thumbImage === "") && (
+                    <img
+                        src={getRandomThumbnail("")}
+                        alt="기본 이미지"
+                        style={{
+                            width: '100%',
+                            height: '100%',
+                            objectFit: 'cover',
+                            position: 'absolute',
+                            top: 0,
+                            left: 0
+                        }}
+                    />
+                )}
+            </Box>
             {/* 정보 섹션 */}
             <Box sx={{ display: "flex", flexDirection: "column", flex: "3", padding: 2 }}>
                 <CardContent>

--- a/src/pages/camp/CampDetail.js
+++ b/src/pages/camp/CampDetail.js
@@ -13,7 +13,7 @@ import {
     CampDatePicker,
     ModalComponent
 } from 'components';
-import { defaultThumbnails, getRandomThumbnail } from "utils/ThumbnailUtils"; // 랜덤 썸네일 유틸 임포트
+import { getRandomThumbnail } from "utils/ThumbnailUtils";
 import { ko } from "date-fns/locale";
 import "react-datepicker/dist/react-datepicker.css";
 import "../../style/camp-detail.css";


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

나의예약목록에 디폴트 이미지 못 불러오는 버그 해결

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 나의예약목록에 디폴트 이미지인경우가 원래 썸네일이미지인 경우의 코드를 분리함

## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.
- 원래 썸네일은 데이터값 그대로 url경로로, 디폴트이미지는 img 태그로 출력

## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [x] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/462a3597-411d-44f7-aac0-8c3514319fdf">

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #151
