### PR TITLE
fix: #166 디폴트 썸네일이미지 안불러와짐 해결

### DIFF
--- a/src/components/reservation/CampReservationCard.js
+++ b/src/components/reservation/CampReservationCard.js
@@ -61,7 +61,7 @@ const CampReservationCard = ({data, onReviewChange}) => {
     } = useApi(reservationService.cancelReservation);
 
     const handleNameClick = () => {
-        navigate(`/camps/${campResponseDto.id}`);
+        navigate(`/camps/${campResponseDto.campId}`);
     };
 
     const handleCancelClick = (reservationId) => {
@@ -74,8 +74,8 @@ const CampReservationCard = ({data, onReviewChange}) => {
             if (localStatus === "예약완료" && selectedReservationId) {
                 const requestData = {
                     id: selectedReservationId,
-                    campId: campResponseDto.id,
-                    campSiteId: campSiteResponseDto.id,
+                    campId: campResponseDto.campId,
+                    campSiteId: campSiteResponseDto.siteId,
                     status: localStatus,
                     cancelReason,
                 };
@@ -114,7 +114,7 @@ const CampReservationCard = ({data, onReviewChange}) => {
     const handleReviewSubmit = async (formData) => {
         try {
             await reviewService.createReview(
-                campResponseDto.id,
+                campResponseDto.campId,
                 data.id,
                 formData
             );
@@ -173,6 +173,7 @@ const CampReservationCard = ({data, onReviewChange}) => {
     };
 
     const buttonProps = getButtonProps();
+    const thumbnailUrl = campResponseDto.thumbImage || getRandomThumbnail("", campResponseDto.campId);
 
     return (
         <Card
@@ -188,33 +189,16 @@ const CampReservationCard = ({data, onReviewChange}) => {
             {/* 이미지 섹션 */}
             <Box
                 sx={{
-                    flex: {sm: "2"},
-                    height: {xs: 200, sm: "auto"},
-                    aspectRatio: {sm: "16 / 9"},
-                    width: {xs: "100%", sm: "auto"},
-                    ...(campResponseDto.thumbImage ? {
-                        backgroundImage: `url(${campResponseDto.thumbImage})`,
-                        backgroundSize: "cover",
-                        backgroundPosition: "center",
-                    } : {
-                        position: 'relative'
-                    })
+                    flex: { sm: "2" },
+                    height: { xs: 200, sm: "auto" },
+                    aspectRatio: { sm: "16 / 9" },
+                    width: { xs: "100%", sm: "auto" },
+                    backgroundImage: `url(${thumbnailUrl})`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                    position: 'relative'
                 }}
             >
-                {(!campResponseDto.thumbImage || campResponseDto.thumbImage === "") && (
-                    <img
-                        src={getRandomThumbnail("", data.campId)}
-                        alt="기본 이미지"
-                        style={{
-                            width: '100%',
-                            height: '100%',
-                            objectFit: 'cover',
-                            position: 'absolute',
-                            top: 0,
-                            left: 0
-                        }}
-                    />
-                )}
             </Box>
             {/* 정보 섹션 */}
             <Box sx={{display: "flex", flexDirection: "column", flex: "3", padding: 2}}>
@@ -229,7 +213,7 @@ const CampReservationCard = ({data, onReviewChange}) => {
                     <Box sx={{display: "flex", alignItems: "center", marginBottom: 1}}>
                         <LocationOnOutlinedIcon sx={{fontSize: 20, marginRight: 1, color: "green"}}/>
                         <Typography variant="body2">
-                            {campAddrResponseDto.streetAddr} {campAddrResponseDto.city.detailedAddr}
+                            {campAddrResponseDto.streetAddr}
                         </Typography>
                     </Box>
                     <Box sx={{display: "flex", alignItems: "center", marginBottom: 1}}>


### PR DESCRIPTION
## 📌 목적
> 이 PR이 해결하려는 문제나 추가하려는 기능의 목적을 간단히 설명해주세요.

디폴트 썸네일이미지 안불러와짐 해결

## 🛠️ 작업 상세 내용
> 작업한 내용에 대한 설명을 체크리스트 형식으로 작성해주세요.
- [x] 디폴트이미지 안불러와지는 곳(다가오는예약, 나의예약에서 카드 컴포넌트) 수정
- [x] 예약 정보 조회 응답 바디에 담긴 id 필드명들이 바뀜


## 🔍 변경 사항
> 코드 변경 사항을 요약하고 중요한 부분을 설명해주세요.


## ✅ 테스트 방법
> 변경된 코드가 어떻게 테스트되었는지 설명해주세요.
1. [ ] 테스트 케이스 작성
2. [ ] 로컬 환경에서 직접 테스트
3. [ ] 기타:

## ⚠️ 주의 사항
> 코드 변경 시 고려해야 할 점이나 리뷰어가 주의해야 할 점이 있으면 작성해주세요.

BE쪽과 함께 머지해주세욧

## 📸 스크린샷 (선택 사항)
> 변경된 기능이 있으면 스크린샷이나 동영상을 추가해주세요.

## 🔗 참고 사항
> 관련된 이슈 번호를 언급해주세요. 추가 참고할 만한 자료나 링크가 있으면 작성해주세요.
- Closes #166
