### PR TITLE
Fix/#193 스마트폰 지도 URL 접속 문제

### DIFF
--- a/src/components/camp/KakaoMap.js
+++ b/src/components/camp/KakaoMap.js
@@ -49,7 +49,7 @@ const KakaoMap = ({ latitude, longitude, locationName, state }) => {
                 });
 
                 // 마커 클릭 시 카카오맵 웹 페이지로 이동 (검색된 상태)
-                const kakaoMapLink = `https://map.kakao.com/link/search/${state} ${locationName}`;
+                const kakaoMapLink = `https://map.kakao.com/link/search/${encodeURIComponent(`${state} ${locationName}`)}`;
                 window.kakao.maps.event.addListener(marker, 'click', () => {
                     window.open(kakaoMapLink, '_blank');
                 });


### PR DESCRIPTION
## 📌 목적
- 스마트폰 접속시 특수 문자 깨짐을 방지하기 위해서
- ex) (주) 아웃오브파크

## 🛠️ 작업 상세 내용
- URL 인코딩 추가
